### PR TITLE
Remove delay before recording starts

### DIFF
--- a/Sources/ApertureCLI/main.swift
+++ b/Sources/ApertureCLI/main.swift
@@ -29,6 +29,10 @@ func record() throws {
     videoCodec: options.videoCodec
   )
 
+  recorder.onStart = {
+    print("FR")
+  }
+
   recorder.onFinish = {
     exit(0)
   }

--- a/Sources/ApertureCLI/main.swift
+++ b/Sources/ApertureCLI/main.swift
@@ -14,6 +14,8 @@ struct Options: Decodable {
 }
 
 func record() throws {
+  setbuf(__stdoutp, nil)
+
   let options: Options = try CLI.arguments.first!.jsonDecoded()
 
   let recorder = try Aperture(
@@ -26,10 +28,6 @@ func record() throws {
     audioDevice: options.audioDeviceId != nil ? AVCaptureDevice(uniqueID: options.audioDeviceId!) : nil,
     videoCodec: options.videoCodec
   )
-
-  recorder.onStart = {
-    print("R")
-  }
 
   recorder.onFinish = {
     exit(0)
@@ -48,7 +46,9 @@ func record() throws {
 
   recorder.start()
 
-  setbuf(__stdoutp, nil)
+  // Inform the Node.js code that the recording has started.
+  print("R")
+
   RunLoop.main.run()
 }
 

--- a/example.js
+++ b/example.js
@@ -10,6 +10,8 @@ async function main() {
   console.log('Preparing to record for 5 seconds');
   await recorder.startRecording();
   console.log('Recording started');
+  await recorder.isFileReady;
+  console.log('File is ready');
   await delay(5000);
   const fp = await recorder.stopRecording();
   fs.renameSync(fp, 'recording.mp4');

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ class Aperture {
     audioDeviceId = undefined,
     videoCodec = undefined
   } = {}) {
+    console.log('1', new Date());
     return new Promise((resolve, reject) => {
       if (this.recorder !== undefined) {
         reject(new Error('Call `.stopRecording()` first'));
@@ -123,6 +124,7 @@ class Aperture {
         debuglog(data);
 
         if (data.trim() === 'R') {
+          console.log('2', new Date());
           // `R` is printed by Swift when the recording **actually** starts
           clearTimeout(timeout);
           resolve(this.tmpPath);

--- a/index.js
+++ b/index.js
@@ -128,6 +128,24 @@ class Aperture {
           // `R` is printed by Swift when the recording **actually** starts
           clearTimeout(timeout);
           resolve(this.tmpPath);
+
+
+          // Start printing how many seconds have passed since
+          // the promise resolved, (every 0.1s) for 3 seconds
+          // Then, we can check the resulting recording to see the first
+          // number of these printed
+          const startDate = new Date();
+          const print = () => {
+            const diff = new Date() - startDate
+            console.log(diff/1000);
+
+            if (diff < 3000) {
+              setTimeout(print, 100);
+            }
+          };
+          print();
+
+
         }
       });
     });

--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,13 @@ Map {
 
 #### recorder.startRecording([[options]](#options))
 
-Returns a `Promise` for the path to the screen recording file.
+Returns a `Promise` that fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
 
-Fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
+#### recorder.isFileReady
+
+`Promise` that fullfills with the path to the screen recording file when it's ready.
+
+Only available while a recording is happening, `undefined` otherwise.
 
 #### recorder.stopRecording()
 

--- a/readme.md
+++ b/readme.md
@@ -90,9 +90,11 @@ Returns a `Promise` that fullfills when the recording starts or rejects if the r
 
 #### recorder.isFileReady
 
-`Promise` that fullfills with the path to the screen recording file when it's ready.
+`Promise` that fullfills with the path to the screen recording file when it's ready. This will never reject.
 
 Only available while a recording is happening, `undefined` otherwise.
+
+Usually, this resolves around 1 second before the recording starts, but that's not guaranteed.
 
 #### recorder.stopRecording()
 

--- a/test.js
+++ b/test.js
@@ -25,7 +25,8 @@ test('returns available video codecs', t => {
 
 test('records screen', async t => {
   const recorder = aperture();
-  t.true(fs.existsSync(await recorder.startRecording()));
+  await recorder.startRecording();
+  t.true(fs.existsSync(await recorder.isFileReady));
   await delay(1000);
   const videoPath = await recorder.stopRecording();
   t.true(fs.existsSync(videoPath));


### PR DESCRIPTION
Turns out the recording actually starts right when we call `recorder.start()`. The `.onStart` event is emitted 2-3 seconds later. So the fix is to simply not wait for that event. I'm suspecting that even is when the recording starts writing to the file on disk, not when the actual recording starts.

Fixes #1
Related https://github.com/wulkano/Kap/issues/850#issuecomment-642127662