### PR TITLE
Require macOS 10.13 and add support for pause/resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ yarn.lock
 /Packages
 /*.xcodeproj
 /aperture
+
+recording.mp4

--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "2447e76fac46f3317544a367f942356f4f5df21c",
           "version": "0.2.0"
         }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "3d79b2b5a2e5af52c14e462044702ea7728f5770",
+          "version": "0.1.0"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/wulkano/Aperture",
         "state": {
           "branch": null,
-          "revision": "2447e76fac46f3317544a367f942356f4f5df21c",
-          "version": "0.2.0"
+          "revision": "2b347d60d58ce87f5ebe0269924efabcf8bed9c0",
+          "version": "0.4.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "3d79b2b5a2e5af52c14e462044702ea7728f5770",
-          "version": "0.1.0"
+          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
@@ -15,13 +15,15 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/wulkano/Aperture", from: "0.2.0")
+    .package(url: "https://github.com/wulkano/Aperture", from: "0.2.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.1.0")
   ],
   targets: [
     .target(
       name: "ApertureCLI",
       dependencies: [
-        "Aperture"
+        "Aperture",
+        .product(name: "ArgumentParser", package: "swift-argument-parser")
       ]
     )
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
   name: "ApertureCLI",
   platforms: [
-    .macOS(.v10_12)
+    .macOS(.v10_13)
   ],
   products: [
     .executable(
@@ -15,8 +15,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/wulkano/Aperture", from: "0.2.0"),
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.1.0")
+    .package(url: "https://github.com/wulkano/Aperture", from: "0.4.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.0")
   ],
   targets: [
     .target(

--- a/Sources/ApertureCLI/main.swift
+++ b/Sources/ApertureCLI/main.swift
@@ -1,79 +1,162 @@
 import Foundation
-import AVFoundation
 import Aperture
+import ArgumentParser
 
-struct Options: Decodable {
-  let destination: URL
-  let framesPerSecond: Int
-  let cropRect: CGRect?
-  let showCursor: Bool
-  let highlightClicks: Bool
-  let screenId: CGDirectDisplayID
-  let audioDeviceId: String?
-  let videoCodec: String?
+enum OutEvent: String, CaseIterable, ExpressibleByArgument {
+  case onStart
+  case onFileReady
+  case onPause
+  case onResume
+  case onFinish
 }
 
-func record() throws {
-  let options: Options = try CLI.arguments.first!.jsonDecoded()
-
-  let recorder = try Aperture(
-    destination: options.destination,
-    framesPerSecond: options.framesPerSecond,
-    cropRect: options.cropRect,
-    showCursor: options.showCursor,
-    highlightClicks: options.highlightClicks,
-    screenId: options.screenId == 0 ? .main : options.screenId,
-    audioDevice: options.audioDeviceId != nil ? AVCaptureDevice(uniqueID: options.audioDeviceId!) : nil,
-    videoCodec: options.videoCodec
-  )
-
-  recorder.onStart = {
-    print("R")
-  }
-
-  recorder.onFinish = {
-    exit(0)
-  }
-
-  recorder.onError = {
-    print($0, to: .standardError)
-    exit(1)
-  }
-
-  CLI.onExit = {
-    recorder.stop()
-    // Do not call `exit()` here as the video is not always done
-    // saving at this point and will be corrupted randomly
-  }
-
-  recorder.start()
-
-  setbuf(__stdoutp, nil)
-  RunLoop.main.run()
+enum InEvent: String, CaseIterable, ExpressibleByArgument {
+  case pause
+  case resume
+  case isPaused
+  case onPause
 }
 
-func showUsage() {
-  print(
-    """
-    Usage:
-      aperture <options>
-      aperture list-screens
-      aperture list-audio-devices
-    """
+extension CaseIterable {
+  static func toStringArray() -> String {
+    return allCases.map { "\($0)" }.joined(separator: ", ")
+  }
+}
+
+struct ApertureCLI: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "aperture",
+    subcommands: [List.self, Record.self, Events.self]
   )
 }
 
-switch CLI.arguments.first {
-case "list-screens":
-  print(try toJson(Devices.screen()), to: .standardError)
-  exit(0)
-case "list-audio-devices":
-  // Uses stderr because of unrelated stuff being outputted on stdout
-  print(try toJson(Devices.audio()), to: .standardError)
-  exit(0)
-case .none:
-  showUsage()
-  exit(1)
-default:
-  try record()
+extension ApertureCLI {
+  struct List: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      subcommands: [Screens.self, AudioDevices.self]
+    )
+  }
+
+  struct Record: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Start a recording with the given options.")
+
+    @Option(name: .shortAndLong, default: "main", help: "The id to use for this process")
+    var processId: String
+
+    @Argument(help: "Stringified JSON object with options passed to Aperture")
+    var options: String
+
+    mutating func run() throws {
+      try record(options, processId: processId)
+    }
+  }
+
+  struct Events: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      subcommands: [Send.self, Listen.self, ListenAll.self]
+    )
+  }
 }
+
+extension ApertureCLI.List {
+  struct Screens: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "List available screens.")
+
+    mutating func run() throws {
+      // Uses stderr because of unrelated stuff being outputted on stdout
+      print(try toJson(Devices.screen()), to: .standardError)
+    }
+  }
+
+  struct AudioDevices: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "List available audio devices.")
+
+    mutating func run() throws {
+      // Uses stderr because of unrelated stuff being outputted on stdout
+      print(try toJson(Devices.audio()), to: .standardError)
+    }
+  }
+}
+
+extension ApertureCLI.Events {
+  struct Send: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Send an event to the given process.")
+
+    @Flag(default: true, inversion: .prefixedNo, help: "Wait for event to be received")
+    var wait: Bool
+
+    @Option(name: .shortAndLong, default: "main", help: "The id of the target process")
+    var processId: String
+
+    @Argument(help: "Name of the event to send. Can be one of:\n\(InEvent.toStringArray())")
+    var event: InEvent
+
+    @Argument(help: "Data to pass to the event")
+    var data: String?
+
+    mutating func run() {
+      sendEvent(processId: processId, event: event.rawValue, data: data) { notification in
+        if let data = notification.getData() {
+          print(data)
+        }
+
+        Foundation.exit(0)
+      }
+
+      if wait {
+        RunLoop.main.run()
+      }
+    }
+  }
+
+  struct Listen: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Listen to an outcoming event for the given process.")
+
+    @Flag(help: "Exit after receiving the event once")
+    var exit: Bool
+
+    @Option(name: .shortAndLong, default: "main", help: "The id of the target process")
+    var processId: String
+
+    @Argument(help: "Name of the event to listen for. Can be one of:\n\(OutEvent.toStringArray())")
+    var event: OutEvent
+
+    func run() {
+      _ = answerEvent(processId: processId, event: event.rawValue) { notification in
+        if let data = notification.getData() {
+          print(data)
+        }
+
+        if self.exit {
+          notification.answer()
+          Foundation.exit(0)
+        }
+      }
+
+      RunLoop.main.run()
+    }
+  }
+
+  struct ListenAll: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Listen to all outcoming events for the given process.")
+
+    @Option(name: .shortAndLong, default: "main", help: "The id of the target process")
+    var processId: String
+
+    func run() {
+      for event in OutEvent.allCases {
+        _ = answerEvent(processId: processId, event: event.rawValue) { notification in
+          if let data = notification.getData() {
+            print("\(event) \(data)")
+          } else {
+            print(event)
+          }
+        }
+      }
+
+      RunLoop.main.run()
+    }
+  }
+}
+
+ApertureCLI.main()

--- a/Sources/ApertureCLI/notifications.swift
+++ b/Sources/ApertureCLI/notifications.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 class ApertureNotification {
+  static func notificationName(forEvent event: String, processId: String) -> String {
+    return "aperture.\(processId).\(event)"
+  }
+
   private var notification: Notification
   var isAnswered: Bool = false
 
@@ -12,31 +16,27 @@ class ApertureNotification {
     return notification.userInfo?[name] as? T
   }
 
-  func getData() -> String? {
+  var data: String? {
     return getField("data")
   }
 
-  func answer() {
-    answer(nil)
-  }
-
-  func answer(_ data: Any?) {
+  func answer(_ data: Any? = nil) {
     isAnswered = true
 
-    let responseName: String? = getField("responseName")
+    let responseIdentifier: String? = getField("responseIdentifier")
 
-    guard responseName != nil else {
+    guard responseIdentifier != nil else {
       return
     }
 
     var payload: [AnyHashable: Any] = [:]
 
-    if data != nil {
-      payload["data"] = "\(data!)"
+    if let payloadData = data {
+      payload["data"] = "\(payloadData)"
     }
 
     DistributedNotificationCenter.default().postNotificationName(
-      NSNotification.Name(responseName!),
+      NSNotification.Name(responseIdentifier!),
       object: nil,
       userInfo: payload,
       deliverImmediately: true
@@ -44,66 +44,69 @@ class ApertureNotification {
   }
 }
 
-func answerEvent(
-  processId: String,
-  event: String,
-  using handler: @escaping (ApertureNotification) -> Void
-) -> NSObjectProtocol {
-  return DistributedNotificationCenter.default().addObserver(
-    forName: NSNotification.Name("aperture.\(processId).\(event)"),
-    object: nil,
-    queue: nil
-  ) { notification in
-    let apertureNotification = ApertureNotification(notification)
-    handler(apertureNotification)
+enum ApertureEvents {
+  static func answerEvent(
+    processId: String,
+    event: String,
+    using handler: @escaping (ApertureNotification) -> Void
+  ) -> NSObjectProtocol {
+    return DistributedNotificationCenter.default().addObserver(
+      forName: NSNotification.Name(
+        ApertureNotification.notificationName(forEvent: event, processId: processId)
+      ),
+      object: nil,
+      queue: nil
+    ) { notification in
+      let apertureNotification = ApertureNotification(notification)
+      handler(apertureNotification)
 
-    if !apertureNotification.isAnswered {
-      apertureNotification.answer()
+      if !apertureNotification.isAnswered {
+        apertureNotification.answer()
+      }
     }
   }
-}
 
-func sendEvent(
-  processId: String,
-  event: String,
-  data: Any?,
-  using callback: @escaping (ApertureNotification) -> Void
-) {
-  let responseName = "aperture.\(processId).\(event).response.\(UUID().uuidString)"
+  static func sendEvent(
+    processId: String,
+    event: String,
+    data: Any?,
+    using callback: @escaping (ApertureNotification) -> Void
+  ) {
+    let notificationName = ApertureNotification.notificationName(forEvent: event, processId: processId)
+    let responseIdentifier = "\(notificationName).response.\(UUID().uuidString)"
 
-  var payload: [AnyHashable: Any] = ["responseName": responseName]
+    var payload: [AnyHashable: Any] = ["responseIdentifier": responseIdentifier]
 
-  if data != nil {
-    payload["data"] = "\(data!)"
+    if let payloadData = data {
+      payload["data"] = "\(payloadData)"
+    }
+
+    var observer: AnyObject?
+
+    observer = DistributedNotificationCenter.default().addObserver(
+      forName: NSNotification.Name(responseIdentifier),
+      object: nil,
+      queue: nil
+    ) { notification in
+      DistributedNotificationCenter.default().removeObserver(observer!)
+      callback(ApertureNotification(notification))
+    }
+
+    DistributedNotificationCenter.default().postNotificationName(
+      NSNotification.Name(
+        ApertureNotification.notificationName(forEvent: event, processId: processId)
+      ),
+      object: nil,
+      userInfo: payload,
+      deliverImmediately: true
+    )
   }
 
-  var observer: Any?
-
-  observer = DistributedNotificationCenter.default().addObserver(
-    forName: NSNotification.Name(responseName),
-    object: nil,
-    queue: nil
-  ) { notification in
-    DistributedNotificationCenter.default().removeObserver(observer!)
-    callback(ApertureNotification(notification))
+  static func sendEvent(processId: String, event: String, using callback: @escaping (ApertureNotification) -> Void) {
+    sendEvent(processId: processId, event: event, data: nil, using: callback)
   }
 
-  DistributedNotificationCenter.default().postNotificationName(
-    NSNotification.Name("aperture.\(processId).\(event)"),
-    object: nil,
-    userInfo: payload,
-    deliverImmediately: true
-  )
-}
-
-func sendEvent(processId: String, event: String, using callback: @escaping (ApertureNotification) -> Void) {
-  sendEvent(processId: processId, event: event, data: nil, using: callback)
-}
-
-func sendEvent(processId: String, event: String) {
-  sendEvent(processId: processId, event: event, data: nil) { _ in }
-}
-
-func sendEvent(processId: String, event: String, data: Any?) {
-  sendEvent(processId: processId, event: event, data: data) { _ in }
+  static func sendEvent(processId: String, event: String, data: Any? = nil) {
+    sendEvent(processId: processId, event: event, data: data) { _ in }
+  }
 }

--- a/Sources/ApertureCLI/notifications.swift
+++ b/Sources/ApertureCLI/notifications.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+class ApertureNotification {
+  private var notification: Notification
+  var isAnswered: Bool = false
+
+  init(_ notification: Notification) {
+    self.notification = notification
+  }
+
+  func getField<T>(_ name: String) -> T? {
+    return notification.userInfo?[name] as? T
+  }
+
+  func getData() -> String? {
+    return getField("data")
+  }
+
+  func answer() {
+    answer(nil)
+  }
+
+  func answer(_ data: Any?) {
+    isAnswered = true
+
+    let responseName: String? = getField("responseName")
+
+    guard responseName != nil else {
+      return
+    }
+
+    var payload: [AnyHashable: Any] = [:]
+
+    if data != nil {
+      payload["data"] = "\(data!)"
+    }
+
+    DistributedNotificationCenter.default().postNotificationName(
+      NSNotification.Name(responseName!),
+      object: nil,
+      userInfo: payload,
+      deliverImmediately: true
+    )
+  }
+}
+
+func answerEvent(
+  processId: String,
+  event: String,
+  using handler: @escaping (ApertureNotification) -> Void
+) -> NSObjectProtocol {
+  return DistributedNotificationCenter.default().addObserver(
+    forName: NSNotification.Name("aperture.\(processId).\(event)"),
+    object: nil,
+    queue: nil
+  ) { notification in
+    let apertureNotification = ApertureNotification(notification)
+    handler(apertureNotification)
+
+    if !apertureNotification.isAnswered {
+      apertureNotification.answer()
+    }
+  }
+}
+
+func sendEvent(
+  processId: String,
+  event: String,
+  data: Any?,
+  using callback: @escaping (ApertureNotification) -> Void
+) {
+  let responseName = "aperture.\(processId).\(event).response.\(UUID().uuidString)"
+
+  var payload: [AnyHashable: Any] = ["responseName": responseName]
+
+  if data != nil {
+    payload["data"] = "\(data!)"
+  }
+
+  var observer: Any?
+
+  observer = DistributedNotificationCenter.default().addObserver(
+    forName: NSNotification.Name(responseName),
+    object: nil,
+    queue: nil
+  ) { notification in
+    DistributedNotificationCenter.default().removeObserver(observer!)
+    callback(ApertureNotification(notification))
+  }
+
+  DistributedNotificationCenter.default().postNotificationName(
+    NSNotification.Name("aperture.\(processId).\(event)"),
+    object: nil,
+    userInfo: payload,
+    deliverImmediately: true
+  )
+}
+
+func sendEvent(processId: String, event: String, using callback: @escaping (ApertureNotification) -> Void) {
+  sendEvent(processId: processId, event: event, data: nil, using: callback)
+}
+
+func sendEvent(processId: String, event: String) {
+  sendEvent(processId: processId, event: event, data: nil) { _ in }
+}
+
+func sendEvent(processId: String, event: String, data: Any?) {
+  sendEvent(processId: processId, event: event, data: data) { _ in }
+}

--- a/Sources/ApertureCLI/record.swift
+++ b/Sources/ApertureCLI/record.swift
@@ -1,0 +1,84 @@
+import AVFoundation
+import Aperture
+
+struct Options: Decodable {
+  let destination: URL
+  let framesPerSecond: Int
+  let cropRect: CGRect?
+  let showCursor: Bool
+  let highlightClicks: Bool
+  let screenId: CGDirectDisplayID
+  let audioDeviceId: String?
+  let videoCodec: String?
+}
+
+func record(_ optionsString: String, processId: String) throws {
+  setbuf(__stdoutp, nil)
+  let options: Options = try optionsString.jsonDecoded()
+  var observers: [Any] = []
+
+  let recorder = try Aperture(
+    destination: options.destination,
+    framesPerSecond: options.framesPerSecond,
+    cropRect: options.cropRect,
+    showCursor: options.showCursor,
+    highlightClicks: options.highlightClicks,
+    screenId: options.screenId == 0 ? .main : options.screenId,
+    audioDevice: options.audioDeviceId != nil ? AVCaptureDevice(uniqueID: options.audioDeviceId!) : nil,
+    videoCodec: options.videoCodec
+  )
+
+  recorder.onStart = {
+    sendEvent(processId: processId, event: OutEvent.onFileReady.rawValue)
+  }
+
+  recorder.onPause = {
+    sendEvent(processId: processId, event: OutEvent.onPause.rawValue)
+  }
+
+  recorder.onResume = {
+    sendEvent(processId: processId, event: OutEvent.onResume.rawValue)
+  }
+
+  recorder.onFinish = {
+    sendEvent(processId: processId, event: OutEvent.onFinish.rawValue)
+    for observer in observers {
+      DistributedNotificationCenter.default().removeObserver(observer)
+    }
+    exit(0)
+  }
+
+  recorder.onError = {
+    print($0, to: .standardError)
+    exit(1)
+  }
+
+  CLI.onExit = {
+    recorder.stop()
+    // Do not call `exit()` here as the video is not always done
+    // saving at this point and will be corrupted randomly
+  }
+
+  observers.append(
+    answerEvent(processId: processId, event: InEvent.pause.rawValue) { _ in
+      recorder.pause()
+    }
+  )
+
+  observers.append(
+    answerEvent(processId: processId, event: InEvent.resume.rawValue) { _ in
+      recorder.resume()
+    }
+  )
+
+  observers.append(
+    answerEvent(processId: processId, event: InEvent.isPaused.rawValue) { notification in
+      notification.answer(recorder.isPaused)
+    }
+  )
+
+  recorder.start()
+  sendEvent(processId: processId, event: OutEvent.onStart.rawValue)
+
+  RunLoop.main.run()
+}

--- a/Sources/ApertureCLI/util.swift
+++ b/Sources/ApertureCLI/util.swift
@@ -97,7 +97,7 @@ extension FileHandle: TextOutputStream {
 }
 
 struct CLI {
-  static var standardInput = FileHandle.standardOutput
+  static var standardInput = FileHandle.standardInput
   static var standardOutput = FileHandle.standardOutput
   static var standardError = FileHandle.standardError
 

--- a/example.js
+++ b/example.js
@@ -7,9 +7,12 @@ async function main() {
   const recorder = aperture();
   console.log('Screens:', await aperture.screens());
   console.log('Audio devices:', await aperture.audioDevices());
+
   console.log('Preparing to record for 5 seconds');
   await recorder.startRecording();
   console.log('Recording started');
+  await recorder.isFileReady
+  console.log('File is ready');
   await delay(5000);
   const fp = await recorder.stopRecording();
   fs.renameSync(fp, 'recording.mp4');

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class Aperture {
     videoCodec = undefined
   } = {}) {
     this.processId = getRandomId();
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       if (this.recorder !== undefined) {
         reject(new Error('Call `.stopRecording()` first'));
         return;
@@ -134,9 +134,10 @@ class Aperture {
       this.recorder.stdout.setEncoding('utf8');
       this.recorder.stdout.on('data', debuglog);
 
-      await this.waitForEvent('onStart');
-      clearTimeout(timeout);
-      setTimeout(() => resolve(this.tmpPath), 1000);
+      this.waitForEvent('onStart').then(() => {
+        clearTimeout(timeout);
+        setTimeout(() => resolve(this.tmpPath), 1000);
+      });
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -182,24 +182,34 @@ class Aperture {
     }
   }
 
+  throwIfNotStarted() {
+    if (this.recorder === undefined) {
+      throw new Error('Call `.startRecording()` first');
+    }
+  }
+
   async pause() {
-    return this.sendEvent('pause');
+    this.throwIfNotStarted();
+
+    await this.sendEvent('pause');
   }
 
   async resume() {
+    this.throwIfNotStarted();
+
     await this.sendEvent('resume');
     // It takes about 1s after the promise resolves for the recording to actually start
     await delay(1000);
   }
 
   async isPaused() {
+    this.throwIfNotStarted();
+
     return this.sendEvent('isPaused', val => val === 'true');
   }
 
   async stopRecording() {
-    if (this.recorder === undefined) {
-      throw new Error('Call `.startRecording()` first');
-    }
+    this.throwIfNotStarted();
 
     this.recorder.kill();
     await this.recorder;

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ class Aperture {
         this.recorder.kill();
         delete this.recorder;
         reject(err);
-      }, 10000);
+      }, 5000);
 
       this.recorder.catch(error => {
         clearTimeout(timeout);

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class Aperture {
     audioDeviceId = undefined,
     videoCodec = undefined
   } = {}) {
-    this.processId = 'asd';//getRandomId();
+    this.processId = getRandomId();
     return new Promise((resolve, reject) => {
       if (this.recorder !== undefined) {
         reject(new Error('Call `.stopRecording()` first'));

--- a/index.js
+++ b/index.js
@@ -110,7 +110,10 @@ class Aperture {
         ]
       );
 
-      this.isFileReady = this.waitForEvent('onFileReady').then(() => this.tmpPath);
+      this.isFileReady = (async () => {
+        await this.waitForEvent('onFileReady');
+        return this.tmpPath;
+      })();
 
       const timeout = setTimeout(() => {
         // `.stopRecording()` was called already
@@ -131,17 +134,18 @@ class Aperture {
         reject(error);
       });
 
-      this.isFileReady = new Promise(resolve => {
-        this._fileReadyResolve = resolve;
-      });
-
       this.recorder.stdout.setEncoding('utf8');
       this.recorder.stdout.on('data', debuglog);
 
-      this.waitForEvent('onStart').then(() => {
-        clearTimeout(timeout);
-        setTimeout(resolve, 1000);
-      });
+      (async () => {
+        try {
+          await this.waitForEvent('onStart');
+          clearTimeout(timeout);
+          setTimeout(resolve, 1000);
+        } catch (error) {
+          reject(error);
+        }
+      })();
     });
   }
 

--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,29 @@ Map {
 
 #### recorder.startRecording([[options]](#options))
 
-Returns a `Promise` for the path to the screen recording file.
+Returns a `Promise` that fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
 
-Fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
+#### recorder.isFileReady
+
+`Promise` that fullfills with the path to the screen recording file when it's ready.
+
+Fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.	Only available while a recording is happening, `undefined` otherwise.
+
+#### recorder.pause()
+
+Pauses the recording. To resume, call `recorder.resume()`.
+
+Returns a `Promise` that fullfills when the recording has been paused.
+
+#### recorder.resume()
+
+Resumes the recording if it's been paused.
+
+Returns a `Promise` that fullfills when the recording has been resumed.
+
+#### recorder.isPaused()
+
+Returns a `Promise` that resolves with a boolean indicating whether or not the recording is currently paused.
 
 #### recorder.stopRecording()
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 $ npm install aperture
 ```
 
-*Requires macOS 10.12 or later.*
+*Requires macOS 10.13 or later.*
 
 
 ## Usage


### PR DESCRIPTION
Closes #2 
Closes #5 
Closes #1

Also replaces #12 (re-implemented those changes here)

So, this has a bunch of changes:

- Adds swift-argument-parser for the CLI part to manage commands, since now they have increased a lot
- Adds a two way communication capability between the main aperture process and the node instance via:
  - Ability to send events (and get a response)
  - Ability to listen to events

Aperture sends events like `onStart`, `onPause` etc that we can listen to, and we can send events to Aperture like `pause`, `resume` to access functionality.

The communication happens using `DistributedNotificationCenter` and specifically mapped event names, inspired by how `electron-better-ipc` works.
This is sandboxed to a single aperture process using a randomly generated `processId` which is included in the events.

Also, the events can answer back using another unique id that is generated on the spot for each event. This way two parallel events of the same type won't get their responses confused.

I've tested the regular flow, including `pause`, `resume` and `isPaused` to ensure it works.

A weird observation. This code:
```
await recorder.startRecording(options);
console.log('Started recording');

recorder.isFileReady.then(() => console.log('File is ready'))

await recorder.pause();
console.log('Paused recording');

await delay(5000)

await recorder.resume();
console.log('Resume recording');
```

Outputs:
```
Started recording
Paused recording
Resumed recording
File is ready
```

And in the output the first frame is after the `resume` call (no time-skip). So, we could theoretically pause right after start, then play a countdown timer or do whatever and then resume, to ensure we start at a convenient time for us.