### PR TITLE
Fix missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "delay": "^5.0.0",
     "electron-util": "^0.14.2",
     "execa": "^5.0.0",
     "file-url": "^3.0.0",
@@ -26,7 +27,6 @@
   },
   "devDependencies": {
     "ava": "^2.4.0",
-    "delay": "^5.0.0",
     "file-type": "^12.0.0",
     "read-chunk": "^3.2.0",
     "tsd": "^0.14.0",


### PR DESCRIPTION
Because the new `delay` dep is in the devDependencies, it's possible that it might not get loaded in.

Edit, for some additional context: Looks like delay was previously just being used for the example/test files. It's now being used in index.js:
https://github.com/wulkano/aperture-node/pull/14/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R202

other option could be to re-use the same sort of logic in start() with resolving in a setTimeout