### PR TITLE
Add scaleFactor to CLI | Add .cancel function

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "47bd06ebeff8146ecd0020809e186218b46f465f",
-          "version": "0.4.2"
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
         }
       }
     ]

--- a/Sources/ApertureCLI/record.swift
+++ b/Sources/ApertureCLI/record.swift
@@ -10,6 +10,7 @@ struct Options: Decodable {
   let screenId: CGDirectDisplayID
   let audioDeviceId: String?
   let videoCodec: String?
+  let scaleFactor: Double?
 }
 
 func record(_ optionsString: String, processId: String) throws {
@@ -25,7 +26,8 @@ func record(_ optionsString: String, processId: String) throws {
     highlightClicks: options.highlightClicks,
     screenId: options.screenId == 0 ? .main : options.screenId,
     audioDevice: options.audioDeviceId != nil ? AVCaptureDevice(uniqueID: options.audioDeviceId!) : nil,
-    videoCodec: options.videoCodec != nil ? AVVideoCodecType(rawValue: options.videoCodec!) : nil
+    videoCodec: options.videoCodec != nil ? AVVideoCodecType(rawValue: options.videoCodec!) : nil,
+    scaleFactor: options.scaleFactor != nil ? options.scaleFactor! : 1
   )
 
   recorder.onStart = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,12 @@ declare namespace aperture {
     The `proRes422` and `proRes4444` codecs are uncompressed data. They will create huge files.
     */
     readonly videoCodec?: VideoCodec;
+
+    /**
+     Scale factor to use
+     Useful when recording retina screens, or for resizing the recorded video
+     */
+    readonly scaleFactor?: number;
   };
 
   interface Recorder {
@@ -101,6 +107,11 @@ declare namespace aperture {
     Returns a `Promise` for the path to the screen recording file.
     */
     stopRecording: () => Promise<string>;
+
+    /**
+     Cancels a recording, if it was started
+     */
+    cancelRecording: () => void;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,9 +63,10 @@ declare namespace aperture {
     readonly videoCodec?: VideoCodec;
 
     /**
-     Scale factor to use
-     Useful when recording retina screens, or for resizing the recorded video
-     */
+    Scale factor to use
+    The actual height and width of the capture will be multiplied by this number to create the height and width of the output.
+    @default 1
+    */
     readonly scaleFactor?: number;
   };
 
@@ -109,9 +110,9 @@ declare namespace aperture {
     stopRecording: () => Promise<string>;
 
     /**
-     Cancels a recording, if it was started
-     */
-    cancelRecording: () => void;
+    Cancels a recording, if it was started
+    */
+    cancel: () => void;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ class Aperture {
     this.recorder.kill();
     delete this.recorder;
     delete this.isFileReady;
-    if(this.recorderTimeout !== undefined) {
+    if (this.recorderTimeout !== undefined) {
       clearTimeout(this.recorderTimeout)
     }
   }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class Aperture {
   }
 
 
-  recorderTimeout = null
+  recorderTimeout = undefined
 
   startRecording({
     fps = 30,
@@ -233,12 +233,16 @@ class Aperture {
     return this.tmpPath;
   }
 
-  cancelRecording() {
-    if (this.recorder !== undefined) {
-      this.recorder.kill();
-      delete this.recorder;
-      delete this.isFileReady;
-      this.recorderTimeout && clearTimeout(this.recorderTimeout)
+  cancel() {
+    if (this.recorder === undefined) {
+      return
+    }
+
+    this.recorder.kill();
+    delete this.recorder;
+    delete this.isFileReady;
+    if(this.recorderTimeout !== undefined) {
+      clearTimeout(this.recorderTimeout)
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,9 @@ Returns a `Promise` that resolves with a boolean indicating whether or not the r
 
 Returns a `Promise` for the path to the screen recording file.
 
+#### recorder.cancel()
+
+Cancels a recoding if it was started
 ## Options
 
 Type: `object`
@@ -153,6 +156,13 @@ Type: `number`\
 Default: `aperture.screens()[0]` *(Primary screen)*
 
 Screen to record.
+
+#### scaleFactor
+
+Type: `number`\
+Default: `1`
+
+The actual height and width of the capture will be multiplied by this number to create the height and width of the output.
 
 #### audioDeviceId
 


### PR DESCRIPTION
## What does it do?
- Adds scale factor argument to CLI and node function
- Adds new `cancel` function to stop and discard the recording

Fixes #18
Please note I haven't had a chance to test this out yet on this version, but I am using something similar in my older fork