### PR TITLE
Fix "Could not start recording within 5 seconds" bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ class Aperture {
 
       (async () => {
         try {
-          await isFileReady;
+          await this.isFileReady;
           clearTimeout(timeout);
           setTimeout(resolve, 1000);
         } catch (error) {

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ class Aperture {
 
       (async () => {
         try {
-          await this.waitForEvent('onStart');
+          await isFileReady;
           clearTimeout(timeout);
           setTimeout(resolve, 1000);
         } catch (error) {


### PR DESCRIPTION
I was running into what I think was a race condition with starting the recorder. Sometimes `this.waitForEvent('onStart')` wasn't returning in time and the timeout was causes the recorder to stop. But when I looked Aperture **was** recording the file.

I think this was because it was calling `this.waitForEvent('onStart')`. Once when `this.isFileReady` was being created and again at the bottom of the `startRecording` method. I was able to fix this problem by relying on `isFileReady` instead of `this.waitForEvent('onStart')`. This avoids shelling out again and still will handle the problem of a recording not starting within 5 seconds.