### PR TITLE
Require Node.js 18, move to ESM and named exports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,18 +5,17 @@ on:
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         node-version:
+          - 20
+          - 18
           - 16
-          - 14
-          - 12
-          - 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/example.js
+++ b/example.js
@@ -1,12 +1,11 @@
 import fs from 'node:fs';
 import timers from 'node:timers/promises';
-import aperture from './index.js';
+import {recorder, screens, audioDevices, videoCodecs} from './index.js';
 
 async function main() {
-	const recorder = aperture();
-	console.log('Screens:', await aperture.screens());
-	console.log('Audio devices:', await aperture.audioDevices());
-	console.log('Video codecs:', aperture.videoCodecs);
+	console.log('Screens:', await screens());
+	console.log('Audio devices:', await audioDevices());
+	console.log('Video codecs:', videoCodecs);
 
 	console.log('Preparing to record for 5 seconds');
 	await recorder.startRecording();

--- a/example.js
+++ b/example.js
@@ -1,7 +1,6 @@
-'use strict';
-const fs = require('fs');
-const delay = require('delay');
-const aperture = require('.');
+import fs from 'node:fs';
+import timers from 'node:timers/promises';
+import aperture from './index.js';
 
 async function main() {
 	const recorder = aperture();
@@ -14,12 +13,16 @@ async function main() {
 	console.log('Recording started');
 	await recorder.isFileReady;
 	console.log('File is ready');
-	await delay(5000);
+	await timers.setTimeout(5000);
 	const fp = await recorder.stopRecording();
 	fs.renameSync(fp, 'recording.mp4');
 	console.log('Video saved in the current directory');
 }
 
-main().catch(console.error);
+try {
+	await main();
+} catch (error) {
+	console.error(error);
+}
 
 // Run: $ node example.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ declare namespace aperture {
 		readonly videoCodec?: VideoCodec;
 	};
 
-	interface Recorder {
+	type Recorder = {
 		/**
 		Returns a `Promise` that fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
 		*/
@@ -101,7 +101,7 @@ declare namespace aperture {
 		Returns a `Promise` for the path to the screen recording file.
 		*/
 		stopRecording: () => Promise<string>;
-	}
+	};
 }
 
 declare const aperture: (() => aperture.Recorder) & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,156 +1,152 @@
-declare namespace aperture {
-	type Screen = {
-		id: number;
-		name: string;
-	};
-
-	type AudioDevice = {
-		id: string;
-		name: string;
-	};
-
-	type VideoCodec = 'h264' | 'hevc' | 'proRes422' | 'proRes4444';
-
-	type RecordingOptions = {
-		/**
-		Number of frames per seconds.
-		*/
-		readonly fps?: number;
-
-		/**
-		Record only an area of the screen.
-		*/
-		readonly cropArea?: {
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-		};
-
-		/**
-		Show the cursor in the screen recording.
-		*/
-		readonly showCursor?: boolean;
-
-		/**
-		Highlight cursor clicks in the screen recording.
-
-		Enabling this will also enable the `showCursor` option.
-		*/
-		readonly highlightClicks?: boolean;
-
-		/**
-		Screen to record.
-
-		Defaults to primary screen.
-		*/
-		readonly screenId?: number;
-
-		/**
-		Audio device to include in the screen recording.
-
-		Should be one of the `id`'s from `aperture.audioDevices()`.
-		*/
-		readonly audioDeviceId?: string;
-
-		/**
-		Video codec to use.
-
-		A computer with Intel 6th generation processor or newer is strongly recommended for the `hevc` codec, as otherwise it will use software encoding, which only produces 3 FPS fullscreen recording.
-
-		The `proRes422` and `proRes4444` codecs are uncompressed data. They will create huge files.
-		*/
-		readonly videoCodec?: VideoCodec;
-	};
-
-	type Recorder = {
-		/**
-		Returns a `Promise` that fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
-		*/
-		startRecording: (options?: RecordingOptions) => Promise<void>;
-
-		/**
-		`Promise` that fullfills with the path to the screen recording file when it's ready. This will never reject.
-
-		Only available while a recording is happening, `undefined` otherwise.
-
-		Usually, this resolves around 1 second before the recording starts, but that's not guaranteed.
-		*/
-		isFileReady: Promise<string> | undefined;
-
-		/**
-		Pauses the recording. To resume, call `recorder.resume()`.
-
-		Returns a `Promise` that fullfills when the recording has been paused.
-		*/
-		pause: () => Promise<void>;
-
-		/**
-		Resumes the recording if it's been paused.
-
-		Returns a `Promise` that fullfills when the recording has been resumed.
-		*/
-		resume: () => Promise<void>;
-
-		/**
-		Returns a `Promise` that resolves with a boolean indicating whether or not the recording is currently paused.
-		*/
-		isPaused: () => Promise<boolean>;
-
-		/**
-		Returns a `Promise` for the path to the screen recording file.
-		*/
-		stopRecording: () => Promise<string>;
-	};
-}
-
-declare const aperture: (() => aperture.Recorder) & {
-	/**
-	Get a list of available video codecs.
-
-	The key is the `videoCodec` option name and the value is the codec name.
-
-	It only returns `hevc` if your computer supports HEVC hardware encoding.
-
-	@example
-	```
-	Map {
-		'h264' => 'H264',
-		'hevc' => 'HEVC',
-		'proRes422' => 'Apple ProRes 422',
-		'proRes4444' => 'Apple ProRes 4444'
-	}
-	```
-	*/
-	videoCodecs: Map<aperture.VideoCodec, string>;
-
-	/**
-	Get a list of screens.
-
-	The first screen is the primary screen.
-
-	@example
-	```
-	[{
-		id: 69732482,
-		name: 'Color LCD'
-	}]
-	```
-	*/
-	screens: () => Promise<aperture.Screen[]>;
-
-	/**
-	Get a list of audio devices.
-
-	@example
-	```
-	[{
-		id: 'AppleHDAEngineInput:1B,0,1,0:1',
-		name: 'Built-in Microphone'
-	}]
-	```
-	*/
-	audioDevices: () => Promise<aperture.AudioDevice[]>;
+export type Screen = {
+	id: number;
+	name: string;
 };
 
-export = aperture;
+export type AudioDevice = {
+	id: string;
+	name: string;
+};
+
+export type VideoCodec = 'h264' | 'hevc' | 'proRes422' | 'proRes4444';
+
+export type RecordingOptions = {
+	/**
+	Number of frames per seconds.
+	*/
+	readonly fps?: number;
+
+	/**
+	Record only an area of the screen.
+	*/
+	readonly cropArea?: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+
+	/**
+	Show the cursor in the screen recording.
+	*/
+	readonly showCursor?: boolean;
+
+	/**
+	Highlight cursor clicks in the screen recording.
+
+	Enabling this will also enable the `showCursor` option.
+	*/
+	readonly highlightClicks?: boolean;
+
+	/**
+	Screen to record.
+
+	Defaults to primary screen.
+	*/
+	readonly screenId?: number;
+
+	/**
+	Audio device to include in the screen recording.
+
+	Should be one of the `id`'s from `audioDevices()`.
+	*/
+	readonly audioDeviceId?: string;
+
+	/**
+	Video codec to use.
+
+	A computer with Intel 6th generation processor or newer is strongly recommended for the `hevc` codec, as otherwise it will use software encoding, which only produces 3 FPS fullscreen recording.
+
+	The `proRes422` and `proRes4444` codecs are uncompressed data. They will create huge files.
+	*/
+	readonly videoCodec?: VideoCodec;
+};
+
+export type Recorder = {
+	/**
+	Returns a `Promise` that fullfills when the recording starts or rejects if the recording didn't start after 5 seconds.
+	*/
+	startRecording: (options?: RecordingOptions) => Promise<void>;
+
+	/**
+	`Promise` that fullfills with the path to the screen recording file when it's ready. This will never reject.
+
+	Only available while a recording is happening, `undefined` otherwise.
+
+	Usually, this resolves around 1 second before the recording starts, but that's not guaranteed.
+	*/
+	isFileReady: Promise<string> | undefined;
+
+	/**
+	Pauses the recording. To resume, call `recorder.resume()`.
+
+	Returns a `Promise` that fullfills when the recording has been paused.
+	*/
+	pause: () => Promise<void>;
+
+	/**
+	Resumes the recording if it's been paused.
+
+	Returns a `Promise` that fullfills when the recording has been resumed.
+	*/
+	resume: () => Promise<void>;
+
+	/**
+	Returns a `Promise` that resolves with a boolean indicating whether or not the recording is currently paused.
+	*/
+	isPaused: () => Promise<boolean>;
+
+	/**
+	Returns a `Promise` for the path to the screen recording file.
+	*/
+	stopRecording: () => Promise<string>;
+};
+
+/**
+Get a list of available video codecs.
+
+The key is the `videoCodec` option name and the value is the codec name.
+
+It only returns `hevc` if your computer supports HEVC hardware encoding.
+
+@example
+```
+Map {
+	'h264' => 'H264',
+	'hevc' => 'HEVC',
+	'proRes422' => 'Apple ProRes 422',
+	'proRes4444' => 'Apple ProRes 4444'
+}
+```
+*/
+export function videoCodecs(): Map<VideoCodec, string>;
+
+/**
+Get a list of screens.
+
+The first screen is the primary screen.
+
+@example
+```
+[{
+	id: 69732482,
+	name: 'Color LCD'
+}]
+```
+*/
+export function screens(): Promise<Screen[]>;
+
+/**
+Get a list of audio devices.
+
+@example
+```
+[{
+	id: 'AppleHDAEngineInput:1B,0,1,0:1',
+	name: 'Built-in Microphone'
+}]
+```
+*/
+export function audioDevices(): Promise<AudioDevice[]>;
+
+export const recorder: Recorder;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ const supportsHevcHardwareEncoding = (() => {
 	const cpuModel = os.cpus()[0].model;
 
 	// All Apple silicon Macs support HEVC hardware encoding.
-	if (cpuModel.startsWith('Apple ')) { // Source string example: `'Apple M1'`
+	if (cpuModel.startsWith('Apple ')) {
+		// Source string example: `'Apple M1'`
 		return true;
 	}
 
@@ -35,7 +36,7 @@ const supportsHevcHardwareEncoding = (() => {
 	return result && Number.parseInt(result[1], 10) >= 6;
 })();
 
-class Aperture {
+class Recorder {
 	constructor() {
 		assertMacOSVersionGreaterThanOrEqualTo('10.13');
 	}
@@ -63,13 +64,12 @@ class Aperture {
 				showCursor = true;
 			}
 
-			if (typeof cropArea === 'object'
-				&& (
-					typeof cropArea.x !== 'number'
+			if (
+				typeof cropArea === 'object'
+				&& (typeof cropArea.x !== 'number'
 					|| typeof cropArea.y !== 'number'
 					|| typeof cropArea.width !== 'number'
-					|| typeof cropArea.height !== 'number'
-				)
+					|| typeof cropArea.height !== 'number')
 			) {
 				reject(new Error('Invalid `cropArea` option object'));
 				return;
@@ -138,14 +138,12 @@ class Aperture {
 				return this.tmpPath;
 			})();
 
-			this.recorder = execa(
-				BIN, [
-					'record',
-					'--process-id',
-					this.processId,
-					JSON.stringify(recorderOptions),
-				],
-			);
+			this.recorder = execa(BIN, [
+				'record',
+				'--process-id',
+				this.processId,
+				JSON.stringify(recorderOptions),
+			]);
 
 			this.recorder.catch(error => {
 				clearTimeout(timeout);
@@ -159,16 +157,14 @@ class Aperture {
 	}
 
 	async waitForEvent(name, parse) {
-		const {stdout} = await execa(
-			BIN, [
-				'events',
-				'listen',
-				'--process-id',
-				this.processId,
-				'--exit',
-				name,
-			],
-		);
+		const {stdout} = await execa(BIN, [
+			'events',
+			'listen',
+			'--process-id',
+			this.processId,
+			'--exit',
+			name,
+		]);
 
 		if (parse) {
 			return parse(stdout.trim());
@@ -176,15 +172,13 @@ class Aperture {
 	}
 
 	async sendEvent(name, parse) {
-		const {stdout} = await execa(
-			BIN, [
-				'events',
-				'send',
-				'--process-id',
-				this.processId,
-				name,
-			],
-		);
+		const {stdout} = await execa(BIN, [
+			'events',
+			'send',
+			'--process-id',
+			this.processId,
+			name,
+		]);
 
 		if (parse) {
 			return parse(stdout.trim());
@@ -229,10 +223,9 @@ class Aperture {
 	}
 }
 
-const aperture = () => new Aperture();
-export default aperture;
+export const recorder = new Recorder();
 
-const screens = async () => {
+export const screens = async () => {
 	const {stderr} = await execa(BIN, ['list', 'screens']);
 
 	try {
@@ -242,11 +235,7 @@ const screens = async () => {
 	}
 };
 
-Object.defineProperty(aperture, 'screens', {
-	value: screens,
-});
-
-const audioDevices = async () => {
+export const audioDevices = async () => {
 	const {stderr} = await execa(BIN, ['list', 'audio-devices']);
 
 	try {
@@ -255,10 +244,6 @@ const audioDevices = async () => {
 		return stderr;
 	}
 };
-
-Object.defineProperty(aperture, 'audioDevices', {
-	value: audioDevices,
-});
 
 const codecs = new Map([
 	['h264', 'H264'],
@@ -271,6 +256,4 @@ if (!supportsHevcHardwareEncoding) {
 	codecs.delete('hevc');
 }
 
-Object.defineProperty(aperture, 'videoCodecs', {
-	value: codecs,
-});
+export const videoCodecs = codecs;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,6 @@
 import {expectType, expectError} from 'tsd';
-import {Recorder, Screen, AudioDevice, VideoCodec} from './index.js';
-
-import aperture = require('./index.js');
+import {type Recorder, type Screen, type AudioDevice, type VideoCodec} from './index.js';
+import aperture from './index.js';
 
 const recorder = aperture();
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,14 +1,12 @@
 import {expectType, expectError} from 'tsd';
-import {type Recorder, type Screen, type AudioDevice, type VideoCodec} from './index.js';
-import aperture from './index.js';
-
-const recorder = aperture();
+import type {Recorder, Screen, AudioDevice, VideoCodec} from './index.js';
+import {recorder, audioDevices, screens, videoCodecs} from './index.js';
 
 expectType<Recorder>(recorder);
 
-expectType<AudioDevice[]>(await aperture.audioDevices());
+expectType<AudioDevice[]>(await audioDevices());
 
-expectType<Screen[]>(await aperture.screens());
+expectType<Screen[]>(await screens());
 
 expectError(recorder.startRecording({videoCodec: 'random'}));
 
@@ -16,4 +14,4 @@ expectType<string | undefined>(await recorder.isFileReady);
 
 expectType<string>(await recorder.stopRecording());
 
-expectType<Map<VideoCodec, string>>(aperture.videoCodecs);
+expectType<Map<VideoCodec, string>>(videoCodecs());

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	"license": "MIT",
 	"repository": "wulkano/aperture-node",
 	"engines": {
-		"node": ">=10"
+		"node": ">=16"
 	},
+	"type": "module",
+	"exports": "./index.js",
 	"scripts": {
 		"test": "xo && ava && tsd",
 		"build": "swift build --configuration=release --arch arm64 --arch x86_64 && mv .build/apple/Products/Release/aperture .",
@@ -18,18 +20,18 @@
 		"index.d.ts"
 	],
 	"dependencies": {
-		"delay": "^5.0.0",
-		"electron-util": "^0.14.2",
-		"execa": "^5.0.0",
-		"file-url": "^3.0.0",
-		"macos-version": "^5.2.1",
-		"tempy": "^1.0.0"
+		"delay": "^6.0.0",
+		"electron-util": "^0.17.2",
+		"execa": "^8.0.1",
+		"file-url": "^4.0.0",
+		"macos-version": "^6.0.0",
+		"tempy": "^3.1.0"
 	},
 	"devDependencies": {
-		"ava": "^2.4.0",
-		"file-type": "^12.0.0",
-		"read-chunk": "^3.2.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"ava": "^5.3.1",
+		"file-type": "^18.7.0",
+		"read-chunk": "^4.0.0",
+		"tsd": "^0.30.7",
+		"xo": "^0.56.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
 	"description": "Record the screen on macOS",
 	"license": "MIT",
 	"repository": "wulkano/aperture-node",
-	"engines": {
-		"node": ">=16"
-	},
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		"types": "./index.d.ts",
+		"default": "./index.js"
+	},
+	"sideEffects": false,
+	"engines": {
+		"node": ">=18"
+	},
 	"scripts": {
 		"test": "xo && ava && tsd",
 		"build": "swift build --configuration=release --arch arm64 --arch x86_64 && mv .build/apple/Products/Release/aperture .",

--- a/readme.md
+++ b/readme.md
@@ -26,15 +26,15 @@ const options = {
 	},
 };
 
-(async () => {
-	await recorder.startRecording(options);
-	await setTimeout(3000);
-	console.log(await recorder.stopRecording());
-	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/cdf4f7df426c97880f8c10a1600879f7.mp4'
-})();
+await recorder.startRecording(options);
+
+await setTimeout(3000);
+
+console.log(await recorder.stopRecording());
+//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/cdf4f7df426c97880f8c10a1600879f7.mp4'
 ```
 
-See [`example.js`](example.js) if you want to quickly try it out. _(The example requires Node.js 16+)_
+See [`example.js`](example.js) if you want to quickly try it out. _(The example requires Node.js 18+)_
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 npm install aperture
 ```
 
-_Requires macOS 10.13 or later._
+*Requires macOS 10.13 or later.*
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -8,15 +8,13 @@
 npm install aperture
 ```
 
-*Requires macOS 10.13 or later.*
+_Requires macOS 10.13 or later._
 
 ## Usage
 
 ```js
 import {setTimeout} from 'node:timers/promises';
-import aperture from 'aperture';
-
-const recorder = aperture();
+import {recorder} from 'aperture';
 
 const options = {
 	fps: 30,
@@ -24,8 +22,8 @@ const options = {
 		x: 100,
 		y: 100,
 		width: 500,
-		height: 500
-	}
+		height: 500,
+	},
 };
 
 (async () => {
@@ -36,37 +34,41 @@ const options = {
 })();
 ```
 
-See [`example.js`](example.js) if you want to quickly try it out. *(The example requires Node.js 16+)*
+See [`example.js`](example.js) if you want to quickly try it out. _(The example requires Node.js 16+)_
 
 ## API
 
-#### aperture.screens() -> `Promise<Object[]>`
+#### screens() -> `Promise<Object[]>`
 
 Get a list of screens. The first screen is the primary screen.
 
 Example:
 
 ```js
-[{
-	id: 69732482,
-	name: 'Color LCD'
-}]
+[
+	{
+		id: 69732482,
+		name: 'Color LCD',
+	},
+];
 ```
 
-#### aperture.audioDevices() -> `Promise<Object[]>`
+#### audioDevices() -> `Promise<Object[]>`
 
 Get a list of audio devices.
 
 Example:
 
 ```js
-[{
-	id: 'AppleHDAEngineInput:1B,0,1,0:1',
-	name: 'Built-in Microphone'
-}]
+[
+	{
+		id: 'AppleHDAEngineInput:1B,0,1,0:1',
+		name: 'Built-in Microphone',
+	},
+];
 ```
 
-#### aperture.videoCodecs -> `Map`
+#### videoCodecs -> `Map`
 
 Get a list of available video codecs. The key is the `videoCodec` option name and the value is the codec name. It only returns `hevc` if your computer supports HEVC hardware encoding.
 
@@ -81,7 +83,7 @@ Map {
 }
 ```
 
-#### recorder = `aperture()`
+#### recorder
 
 #### recorder.startRecording([options?](#options))
 
@@ -152,7 +154,7 @@ Enabling this will also enable the `showCursor` option.
 #### screenId
 
 Type: `number`\
-Default: `aperture.screens()[0]` *(Primary screen)*
+Default: `aperture.screens()[0]` _(Primary screen)_
 
 Screen to record.
 

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,10 @@ npm install aperture
 ## Usage
 
 ```js
-const delay = require('delay');
-const aperture = require('aperture')();
+import {setTimeout} from 'node:timers/promises';
+import aperture from 'aperture';
+
+const recorder = aperture();
 
 const options = {
 	fps: 30,
@@ -27,14 +29,14 @@ const options = {
 };
 
 (async () => {
-	await aperture.startRecording(options);
-	await delay(3000);
-	console.log(await aperture.stopRecording());
+	await recorder.startRecording(options);
+	await setTimeout(3000);
+	console.log(await recorder.stopRecording());
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/cdf4f7df426c97880f8c10a1600879f7.mp4'
 })();
 ```
 
-See [`example.js`](example.js) if you want to quickly try it out. *(The example requires Node.js 8+)*
+See [`example.js`](example.js) if you want to quickly try it out. *(The example requires Node.js 16+)*
 
 ## API
 

--- a/test.js
+++ b/test.js
@@ -3,10 +3,10 @@ import test from 'ava';
 import delay from 'delay';
 import {fileTypeFromBuffer} from 'file-type';
 import {readChunk} from 'read-chunk';
-import aperture from './index.js';
+import {recorder, audioDevices, screens, videoCodecs} from './index.js';
 
 test('returns audio devices', async t => {
-	const devices = await aperture.audioDevices();
+	const devices = await audioDevices();
 	console.log('Audio devices:', devices);
 
 	t.true(Array.isArray(devices));
@@ -17,14 +17,25 @@ test('returns audio devices', async t => {
 	}
 });
 
+test('returns screens', async t => {
+	const monitors = await screens();
+	console.log('Screens:', monitors);
+
+	t.true(Array.isArray(monitors));
+
+	if (monitors.length > 0) {
+		t.true(monitors[0].id > 0);
+		t.true(monitors[0].name.length > 0);
+	}
+});
+
 test('returns available video codecs', t => {
-	const codecs = aperture.videoCodecs;
+	const codecs = videoCodecs;
 	console.log('Video codecs:', codecs);
 	t.true(codecs.has('h264'));
 });
 
 test('records screen', async t => {
-	const recorder = aperture();
 	await recorder.startRecording();
 	t.true(fs.existsSync(await recorder.isFileReady));
 	await delay(1000);

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import test from 'ava';
 import delay from 'delay';
-import readChunk from 'read-chunk';
-import fileType from 'file-type';
+import {fileTypeFromBuffer} from 'file-type';
+import {readChunk} from 'read-chunk';
 import aperture from './index.js';
 
 test('returns audio devices', async t => {
@@ -30,6 +30,8 @@ test('records screen', async t => {
 	await delay(1000);
 	const videoPath = await recorder.stopRecording();
 	t.true(fs.existsSync(videoPath));
-	t.is(fileType(readChunk.sync(videoPath, 0, 4100)).ext, 'mov');
+	const buffer = await readChunk(videoPath, {length: 4100});
+	const fileType = await fileTypeFromBuffer(buffer);
+	t.is(fileType.ext, 'mov');
 	fs.unlinkSync(videoPath);
 });


### PR DESCRIPTION
Followed [ESM docs](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) and your work on other projects.

API Breaking changes:
- `const aperture = require('aperture')` → `import {recorder} from 'aperture'`
- `await aperture().startRecording()` → `await recorder.startRecording`
- `aperture.screens` → `import {screens} from 'aperture'`
- `aperture.audioDevices` → `import {audioDevices} from 'aperture'`
- `aperture.videoCodecs` → `import {videoCodecs} from 'aperture'`

`ava`, `file-type`, `xo` and `electron-util` last versions require Node 18 so I couldn't use them. Do you think it's worth upgrading to Node 18 now?